### PR TITLE
feat: add option to extend mixin using native enqueuers

### DIFF
--- a/lib/background_job.rb
+++ b/lib/background_job.rb
@@ -56,7 +56,7 @@ module BackgroundJob
     end
   end
 
-  def self.mixin(service, **options)
+  def self.mixin(service, native: false, **options)
     service = service.to_sym
     unless SERVICES.key?(service)
       raise Error, "Service `#{service}' is not supported. Supported services are: #{SERVICES.keys.join(', ')}"
@@ -66,7 +66,7 @@ module BackgroundJob
 
     module_name = service.to_s.split(/_/i).collect!{ |w| w.capitalize }.join
     mod = Mixin.const_get(module_name)
-    mod::Builder.new(**options)
+    mod::Builder.new(native: native, **options)
   end
 
   def self.jid

--- a/lib/background_job/mixin/faktory.rb
+++ b/lib/background_job/mixin/faktory.rb
@@ -28,15 +28,16 @@ module BackgroundJob
       end
 
       class Builder < Module
-        def initialize(**options)
+        def initialize(native: false, **options)
+          @native = native
           @runtime_mod = Module.new do
             define_method(:background_job_user_options) { options }
           end
         end
 
         def extended(base)
-          base.include(::Faktory::Job) if defined?(::Faktory)
-          base.extend BackgroundJob::Mixin::SharedInterface
+          base.include(::Faktory::Job) if defined?(::Faktory::Job)
+          base.extend(BackgroundJob::Mixin::SharedInterface) unless @native
           base.extend ClassMethods
           base.extend @runtime_mod
         end


### PR DESCRIPTION
Clients may want to install jobs using native perform_* methods